### PR TITLE
Add basic AutoTester UI and config handling

### DIFF
--- a/controller/daemon/loader.go
+++ b/controller/daemon/loader.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/reef-pi/reef-pi/controller/modules/ato"
+	"github.com/reef-pi/reef-pi/controller/modules/autotester"
 	"github.com/reef-pi/reef-pi/controller/modules/camera"
 	"github.com/reef-pi/reef-pi/controller/modules/doser"
 	"github.com/reef-pi/reef-pi/controller/modules/equipment"
@@ -53,6 +54,15 @@ func (r *ReefPi) loadJournalSubsystem() error {
 		return nil
 	}
 	r.subsystems.Load(journal.Bucket, journal.New(r))
+	return nil
+}
+
+func (r *ReefPi) loadAutoTesterSubsystem() error {
+	if !r.settings.Capabilities.AutoTester {
+		return nil
+	}
+	at := autotester.New(r)
+	r.subsystems.Load(autotester.Bucket, at)
 	return nil
 }
 
@@ -184,6 +194,10 @@ func (r *ReefPi) loadSubsystems() error {
 	if err := r.loadJournalSubsystem(); err != nil {
 		log.Println("ERROR: Failed to load journal subsystem. Error:", err)
 		r.LogError("subsystem-journal", "Failed to load journal subsystem. Error:"+err.Error())
+	}
+	if err := r.loadAutoTesterSubsystem(); err != nil {
+		log.Println("ERROR: Failed to load autotester subsystem. Error:", err)
+		r.LogError("subsystem-autotester", "Failed to load autotester subsystem. Error:"+err.Error())
 	}
 	if err := r.subsystems.Setup(); err != nil {
 		log.Println("ERROR: Failed to setup subsystems. Error:", err)

--- a/controller/daemon/settings.go
+++ b/controller/daemon/settings.go
@@ -48,9 +48,13 @@ func (r *ReefPi) GetSettings(w http.ResponseWriter, req *http.Request) {
 }
 
 func (r *ReefPi) UpdateSettings(w http.ResponseWriter, req *http.Request) {
-	var s settings.Settings
-	fn := func(_ string) error {
-		return r.store.Update(Bucket, "settings", s)
-	}
-	utils.JSONUpdateResponse(&s, fn, w, req)
+        var s settings.Settings
+        fn := func(_ string) error {
+                if err := r.store.Update(Bucket, "settings", s); err != nil {
+                        return err
+                }
+                r.settings = s
+                return nil
+        }
+        utils.JSONUpdateResponse(&s, fn, w, req)
 }

--- a/controller/modules/autotester/api.go
+++ b/controller/modules/autotester/api.go
@@ -1,0 +1,29 @@
+package autotester
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/reef-pi/reef-pi/controller/utils"
+)
+
+// LoadAPI registers autotester REST endpoints.
+func (s *Subsystem) LoadAPI(r *mux.Router) {
+	r.HandleFunc("/api/autotester/config", s.getConfig).Methods("GET")
+	r.HandleFunc("/api/autotester/config", s.updateConfig).Methods("PUT")
+}
+
+func (s *Subsystem) getConfig(w http.ResponseWriter, r *http.Request) {
+	fn := func(_ string) (interface{}, error) {
+		return s.config, nil
+	}
+	utils.JSONGetResponse(fn, w, r)
+}
+
+func (s *Subsystem) updateConfig(w http.ResponseWriter, r *http.Request) {
+	var conf Config
+	fn := func(_ string) error {
+		return s.saveConfig(conf)
+	}
+	utils.JSONUpdateResponse(&conf, fn, w, r)
+}

--- a/controller/modules/autotester/autotester.go
+++ b/controller/modules/autotester/autotester.go
@@ -1,0 +1,63 @@
+package autotester
+
+import (
+	"github.com/reef-pi/reef-pi/controller"
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+const Bucket = storage.AutoTesterBucket
+const UsageBucket = storage.AutoTesterUsageBucket
+
+// Config defines basic configuration for the autotester module.
+type Config struct {
+	Enable bool `json:"enable"`
+}
+
+// Subsystem represents the autotester module controller.
+type Subsystem struct {
+	c      controller.Controller
+	config Config
+}
+
+func (s *Subsystem) loadConfig() error {
+	var conf Config
+	if err := s.c.Store().Get(Bucket, "config", &conf); err != nil {
+		if err == storage.ErrDoesNotExist {
+			conf = Config{}
+			if err := s.c.Store().CreateWithID(Bucket, "config", &conf); err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	s.config = conf
+	return nil
+}
+
+func (s *Subsystem) saveConfig(c Config) error {
+	s.config = c
+	return s.c.Store().Update(Bucket, "config", &s.config)
+}
+
+// New creates a new autotester subsystem instance.
+func New(c controller.Controller) *Subsystem {
+	return &Subsystem{c: c}
+}
+
+func (s *Subsystem) Setup() error {
+	if err := s.c.Store().CreateBucket(Bucket); err != nil {
+		return err
+	}
+	if err := s.c.Store().CreateBucket(UsageBucket); err != nil {
+		return err
+	}
+	return s.loadConfig()
+}
+
+func (s *Subsystem) Start() {}
+func (s *Subsystem) Stop()  {}
+
+func (s *Subsystem) On(id string, b bool) error                     { return nil }
+func (s *Subsystem) InUse(string, string) ([]string, error)         { return []string{}, nil }
+func (s *Subsystem) GetEntity(id string) (controller.Entity, error) { return nil, nil }

--- a/controller/modules/autotester/doc.go
+++ b/controller/modules/autotester/doc.go
@@ -1,0 +1,5 @@
+package autotester
+
+// The AutoTester module automates periodic water tests.
+// swagger:parameters autotesterUpdate autotesterGet
+// This doc file holds swagger documentation for the autotester subsystem.

--- a/controller/settings/capabilities.go
+++ b/controller/settings/capabilities.go
@@ -16,6 +16,7 @@ type Capabilities struct {
 	Macro         bool `json:"macro"`
 	Configuration bool `json:"configuration"`
 	Journal       bool `json:"journal"`
+	AutoTester    bool `json:"autotester"`
 }
 
 var DefaultCapabilities = Capabilities{
@@ -29,4 +30,5 @@ var DefaultCapabilities = Capabilities{
 	ATO:           true,
 	Configuration: true,
 	Macro:         true,
+	AutoTester:    false,
 }

--- a/controller/storage/store.go
+++ b/controller/storage/store.go
@@ -32,6 +32,8 @@ const (
 	DriverBucket                 = "drivers"
 	JournalBucket                = "journal"
 	JournalUsageBucket           = "journal_usage"
+	AutoTesterBucket             = "autotester"
+	AutoTesterUsageBucket        = "autotester_usage"
 )
 
 type ObjectStore interface {

--- a/front-end/assets/translations/de.csv
+++ b/front-end/assets/translations/de.csv
@@ -379,3 +379,4 @@ validation:name_required,Ein Name ist erforderlich!
 validation:number_required,Das muss eine Zahl sein!
 validation:selection_required,Eine Auswahl ist erforderlich!
 validation:time_required,Eine Zeit im Format HH:mm:ss ist erforderlich!
+capabilities:autotester,AutoTester

--- a/front-end/assets/translations/en.csv
+++ b/front-end/assets/translations/en.csv
@@ -379,3 +379,4 @@ validation:name_required,Name is required
 validation:number_required,A number is required
 validation:selection_required,Select one entry
 validation:time_required,Enter a time as HH:mm:ss
+capabilities:autotester,AutoTester

--- a/front-end/assets/translations/es.csv
+++ b/front-end/assets/translations/es.csv
@@ -379,3 +379,4 @@ validation:name_required,
 validation:number_required,
 validation:selection_required,
 validation:time_required,
+capabilities:autotester,AutoTester

--- a/front-end/assets/translations/fa.csv
+++ b/front-end/assets/translations/fa.csv
@@ -379,3 +379,4 @@ validation:name_required,
 validation:number_required,
 validation:selection_required,
 validation:time_required,
+capabilities:autotester,AutoTester

--- a/front-end/assets/translations/fr.csv
+++ b/front-end/assets/translations/fr.csv
@@ -379,3 +379,4 @@ validation:name_required,
 validation:number_required,
 validation:selection_required,
 validation:time_required,
+capabilities:autotester,AutoTester

--- a/front-end/assets/translations/hi.csv
+++ b/front-end/assets/translations/hi.csv
@@ -379,3 +379,4 @@ validation:name_required,
 validation:number_required,
 validation:selection_required,
 validation:time_required,
+capabilities:autotester,AutoTester

--- a/front-end/assets/translations/it.csv
+++ b/front-end/assets/translations/it.csv
@@ -379,3 +379,4 @@ validation:name_required,
 validation:number_required,
 validation:selection_required,
 validation:time_required,
+capabilities:autotester,AutoTester

--- a/front-end/assets/translations/nl.csv
+++ b/front-end/assets/translations/nl.csv
@@ -379,3 +379,4 @@ validation:name_required,
 validation:number_required,
 validation:selection_required,
 validation:time_required,
+capabilities:autotester,AutoTester

--- a/front-end/assets/translations/pt.csv
+++ b/front-end/assets/translations/pt.csv
@@ -379,3 +379,4 @@ validation:name_required,nome é obrigatório
 validation:number_required,numero é obrigatória
 validation:selection_required,Selecção é obrigatória
 validation:time_required,Tempo é obrigatória
+capabilities:autotester,AutoTester

--- a/front-end/assets/translations/zh.csv
+++ b/front-end/assets/translations/zh.csv
@@ -379,3 +379,4 @@ validation:name_required,
 validation:number_required,
 validation:selection_required,
 validation:time_required,
+capabilities:autotester,AutoTester

--- a/front-end/src/autotester/main.jsx
+++ b/front-end/src/autotester/main.jsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { fetchAutotesterConfig } from 'redux/actions/autotester'
+import i18n from 'utils/i18n'
+
+class AutoTester extends React.Component {
+  componentDidMount () {
+    this.props.fetchConfig()
+  }
+
+  render () {
+    const conf = this.props.config || {}
+    return (
+      <div>
+        <h3>{i18n.t('capabilities:autotester')}</h3>
+        <pre>{JSON.stringify(conf)}</pre>
+      </div>
+    )
+  }
+}
+
+const mapStateToProps = state => ({
+  config: state.autotester_config
+})
+
+const mapDispatchToProps = dispatch => ({
+  fetchConfig: () => dispatch(fetchAutotesterConfig())
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(AutoTester)

--- a/front-end/src/configuration/capabilities.jsx
+++ b/front-end/src/configuration/capabilities.jsx
@@ -50,6 +50,7 @@ export default class Capabilities extends React.Component {
           {this.toLi('doser')}
           {this.toLi('ph')}
           {this.toLi('journal')}
+          {this.toLi('autotester')}
           {this.toLi('macro')}
           {this.toLi('health_check')}
           {this.toLi('dashboard')}

--- a/front-end/src/configuration/settings.jsx
+++ b/front-end/src/configuration/settings.jsx
@@ -4,6 +4,7 @@ import Capabilities from './capabilities'
 import Display from './display'
 import HealthNotify from './health_notify'
 import { updateSettings, fetchSettings } from 'redux/actions/settings'
+import { fetchUIData } from 'redux/actions/ui'
 import { connect } from 'react-redux'
 import SettingsSchema from './settings_schema'
 import i18n from 'utils/i18n'
@@ -169,6 +170,8 @@ class settings extends React.Component {
       settings = SettingsSchema.cast(settings)
       this.setState({ updated: false, settings: settings })
       this.props.updateSettings(settings)
+      this.props.fetchSettings()
+      this.props.fetchUIData()
       showUpdateSuccessful()
       return
     }
@@ -326,7 +329,8 @@ const mapStateToProps = state => {
 const mapDispatchToProps = dispatch => {
   return {
     fetchSettings: () => dispatch(fetchSettings()),
-    updateSettings: s => dispatch(updateSettings(s))
+    updateSettings: s => dispatch(updateSettings(s)),
+    fetchUIData: () => dispatch(fetchUIData(dispatch))
   }
 }
 

--- a/front-end/src/main_panel.jsx
+++ b/front-end/src/main_panel.jsx
@@ -21,6 +21,7 @@ import ErrorBoundary from './ui_components/error_boundary'
 import i18n from 'utils/i18n'
 import Instances from 'instances/main'
 import Journal from 'journal/main'
+import AutoTester from 'autotester/main'
 
 
 const routes = [
@@ -36,6 +37,7 @@ const routes = [
   <Route key="camera" path="/camera" element={<Camera />} label={i18n.t('capabilities:camera')} />,
   <Route key="manager" path="/manager" element={<Instances />} label={i18n.t('capabilities:manager')} />,
   <Route key="journal" path="/journal" element={<Journal />} label={i18n.t('capabilities:journal')} />,
+  <Route key="autotester" path="/autotester" element={<AutoTester />} label={i18n.t('capabilities:autotester')} />,
   <Route key="configuration" path="/configuration/*" element={<Configuration />} label={i18n.t('capabilities:configuration')} />,
 ]
 

--- a/front-end/src/redux/actions/autotester.js
+++ b/front-end/src/redux/actions/autotester.js
@@ -1,0 +1,23 @@
+import { reduxGet, reduxPut } from 'utils/ajax'
+
+export const autotesterConfigLoaded = (c) => {
+  return ({
+    type: 'AUTOTESTER_CONFIG_LOADED',
+    payload: c
+  })
+}
+
+export const fetchAutotesterConfig = () => {
+  return reduxGet({
+    url: '/api/autotester/config',
+    success: autotesterConfigLoaded
+  })
+}
+
+export const updateAutotesterConfig = (c) => {
+  return reduxPut({
+    url: '/api/autotester/config',
+    data: c,
+    success: fetchAutotesterConfig
+  })
+}

--- a/front-end/src/redux/reducer.js
+++ b/front-end/src/redux/reducer.js
@@ -80,6 +80,8 @@ export const rootReducer = (state, action) => {
     case 'PH_PROBE_READING_COMPLETE':
       phReading[action.payload.id] = action.payload.reading
       return { ...state, ph_reading: { ...phReading } }
+    case 'AUTOTESTER_CONFIG_LOADED':
+      return { ...state, autotester_config: action.payload }
     case 'CAPABILITIES_LOADED':
       return { ...state, capabilities: action.payload }
     case 'SETTINGS_LOADED':

--- a/front-end/src/redux/store.js
+++ b/front-end/src/redux/store.js
@@ -58,7 +58,8 @@ const initialState = {
   },
   logs: [],
   alerts: [],
-  instances: []
+  instances: [],
+  autotester_config: {}
 }
 const store = createStore(rootReducer, initialState, applyMiddleware(thunk))
 export const configureStore = () => {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "reef-pi",
   "version": "1.0.0",
   "private": true,
+  "packageManager": "yarn@1.22.19",
   "description": "A Raspberry Pi based reeftank automation system",
   "dependencies": {
     "@babel/core": "7.19.6",


### PR DESCRIPTION
## Summary
- implement config persistence for AutoTester subsystem
- expose GET/PUT endpoints for AutoTester config
- add placeholder AutoTester tab in the UI
- wire Redux store and actions for AutoTester
- add translation entry for the new capability

## Testing
- `make test` *(fails: Forbidden storage.googleapis.com)*
- `yarn run standard` *(fails: lockfile missing)*
- `yarn test` *(fails: lockfile missing)*

------
https://chatgpt.com/codex/tasks/task_e_6852e50a8508832c954e8b3848e9cd38